### PR TITLE
Feature: pass data

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Steganography is a a mobile application, with which you can encode messages in t
 - Other:
     - Gradle
     - Navigation Component
+    - Safe Args
 
 ## Design-document
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,4 @@
+
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
@@ -62,4 +63,5 @@ dependencies {
 
     implementation "androidx.activity:activity-ktx:1.7.2"
     implementation "androidx.fragment:fragment-ktx:1.5.7"
+
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,8 @@
-
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'androidx.navigation.safeargs.kotlin'
+
 }
 
 android {
@@ -44,19 +45,20 @@ android {
                             'src/main/res'
                     ]
         }
+        main.java.srcDirs += 'build/generated/source/apt'
     }
     namespace 'com.example.steganography'
 }
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
     implementation "androidx.navigation:navigation-fragment-ktx:2.5.3"
     implementation "androidx.navigation:navigation-ui-ktx:2.5.3"

--- a/app/src/main/java/com/example/steganography/fragments/decode/DecodeResultFragment.kt
+++ b/app/src/main/java/com/example/steganography/fragments/decode/DecodeResultFragment.kt
@@ -1,17 +1,23 @@
 package com.example.steganography.fragments.decode
 
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.navigation.findNavController
+import androidx.navigation.fragment.navArgs
 import com.example.steganography.MainActivity
 import com.example.steganography.R
 import com.example.steganography.databinding.FragmentDecodeResultBinding
+import com.example.steganography.fragments.encode.EncodeResultFragmentArgs
 
 
 class DecodeResultFragment : Fragment(R.layout.fragment_decode_result){
     private lateinit var binding: FragmentDecodeResultBinding
     private var title = "Decode: result"
+
+    private val args : DecodeResultFragmentArgs by navArgs()
+    private val previewImage by lazy { binding.image }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -19,8 +25,13 @@ class DecodeResultFragment : Fragment(R.layout.fragment_decode_result){
         (activity as MainActivity).supportActionBar?.setTitle(title)
 
         binding.toSetup.setOnClickListener { onToSetupPressed(view) }
+        setArgs()
     }
 
+    private fun setArgs() {
+        val imageUri = Uri.parse(args.imageUri)
+        previewImage.setImageURI(imageUri)
+    }
     private fun onToSetupPressed(view: View) {
         view.findNavController().navigate(R.id.action_decodeResultFragment_to_decodeSetupFragment)
     }

--- a/app/src/main/java/com/example/steganography/fragments/decode/DecodeSetupFragment.kt
+++ b/app/src/main/java/com/example/steganography/fragments/decode/DecodeSetupFragment.kt
@@ -2,31 +2,56 @@ package com.example.steganography.fragments.decode
 
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.view.View
+import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import androidx.navigation.findNavController
 import com.example.steganography.MainActivity
 import com.example.steganography.R
 import com.example.steganography.databinding.FragmentDecodeSetupBinding
+import com.example.steganography.fragments.encode.EncodeSetupFragmentDirections
 
 class DecodeSetupFragment : Fragment(R.layout.fragment_decode_setup){
     private lateinit var binding: FragmentDecodeSetupBinding
     private var title = "Decode: setup"
 
+    //for image selection
+    private var latestUri: Uri? = null
     private val previewImage by lazy { binding.image }
-    private val selectImageFromGalleryResult = registerForActivityResult(
-        ActivityResultContracts
-        .GetContent()) { uri: Uri? -> uri?.let { previewImage.setImageURI(uri) }
+    private val selectImageFromGalleryResult = registerForActivityResult(ActivityResultContracts
+        .GetContent()) { uri: Uri? -> uri?.let {
+        previewImage.setImageURI(uri)
+        latestUri = uri
+    }
     }
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding = FragmentDecodeSetupBinding.bind(view)
-        binding.start.setOnClickListener { onStartPressed(view) }
         (activity as MainActivity).supportActionBar?.setTitle(title)
 
+        initButtons(view)
+    }
+
+    private fun initButtons(view: View) {
+        initStartButton(view)
         initLoadPictureButton()
     }
+
+    private fun initStartButton(view: View) {
+        binding.start.setOnClickListener {
+            val imageUri = latestUri.toString()
+            Log.d("d", imageUri)
+            if (latestUri == null) {
+                Toast.makeText(context, "no entry", Toast.LENGTH_SHORT).show()
+            } else {
+                view.findNavController().navigate(
+                    DecodeSetupFragmentDirections.actionDecodeSetupFragmentToDecodeResultFragment(imageUri))
+            }
+        }
+    }
+
 
     private fun onStartPressed(view: View) {
         view.findNavController().navigate(R.id.action_decodeSetupFragment_to_decodeResultFragment)

--- a/app/src/main/java/com/example/steganography/fragments/encode/EncodeResultFragment.kt
+++ b/app/src/main/java/com/example/steganography/fragments/encode/EncodeResultFragment.kt
@@ -1,9 +1,11 @@
 package com.example.steganography.fragments.encode
 
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.navigation.findNavController
+import androidx.navigation.fragment.navArgs
 import com.example.steganography.MainActivity
 import com.example.steganography.R
 import com.example.steganography.databinding.FragmentEncodeResultBinding
@@ -12,12 +14,25 @@ class EncodeResultFragment : Fragment(R.layout.fragment_encode_result){
     private lateinit var binding: FragmentEncodeResultBinding
     private var title = "Encode: result"
 
+    private val args : EncodeResultFragmentArgs by navArgs()
+    private val previewImage by lazy { binding.image }
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding = FragmentEncodeResultBinding.bind(view)
         (activity as MainActivity).supportActionBar?.setTitle(title)
 
         binding.toSetup.setOnClickListener { onToSetupPressed(view) }
+
+        setArgs()
+    }
+
+    private fun setArgs() {
+        // Receive the arguments in a variable
+        val message = this.args.message
+        val imageUri = Uri.parse(this.args.imageUri)
+        // set the values to respective textViews
+        binding.text.text = message
+        previewImage.setImageURI(imageUri)
     }
 
     private fun onToSetupPressed(view: View) {

--- a/app/src/main/res/layouts/decode/layout/fragment_decode_result.xml
+++ b/app/src/main/res/layouts/decode/layout/fragment_decode_result.xml
@@ -44,8 +44,7 @@
             android:layout_height="match_parent"
             android:layout_weight="5"
             android:layout_gravity="center"
-            android:background="@color/orange_100"
-            android:src="@drawable/img_1"/>
+            android:background="@color/orange_100"/>
         <Space
             android:layout_width="0dp"
             android:layout_height="match_parent"

--- a/app/src/main/res/layouts/encode/layout/fragment_encode_result.xml
+++ b/app/src/main/res/layouts/encode/layout/fragment_encode_result.xml
@@ -43,8 +43,7 @@
             android:layout_height="match_parent"
             android:layout_weight="5"
             android:layout_gravity="center"
-            android:background="@color/orange_100"
-            android:src="@drawable/img"/>
+            android:background="@color/orange_100"/>
         <Space
             android:layout_width="0dp"
             android:layout_height="match_parent"

--- a/app/src/main/res/layouts/encode/layout/fragment_encode_setup.xml
+++ b/app/src/main/res/layouts/encode/layout/fragment_encode_setup.xml
@@ -21,7 +21,7 @@
 
 
         <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/text"
+            android:id="@+id/textField"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             app:layout_constraintBottom_toTopOf="@+id/guideline"
@@ -30,6 +30,7 @@
             app:layout_constraintTop_toTopOf="parent">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/text"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:gravity="top"
@@ -82,7 +83,7 @@
             android:layout_height="wrap_content"
             app:icon="@drawable/take_a_picture"
             app:iconGravity="end"
-            android:text="take a"
+            android:text="@string/take_a"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/buttonLoadPicture"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -11,17 +11,30 @@
             tools:layout="@layout/fragment_encode_setup">
             <action
                 android:id="@+id/action_encodeSetupFragment_to_encodeResultFragment"
-                app:destination="@id/encodeResultFragment" />
+                app:destination="@id/encodeResultFragment"
+                app:launchSingleTop="true"
+                app:popUpToInclusive="true">
+            </action>
         </fragment>
         <fragment
             android:id="@+id/encodeResultFragment"
             android:name="com.example.steganography.fragments.encode.EncodeResultFragment"
             android:label="fragment_encode_result"
             tools:layout="@layout/fragment_encode_result" >
+            <argument
+                android:name="message"
+                app:argType="string"/>
+            <argument
+                android:name="imageUri"
+                app:argType="string"/>
             <action
                 android:id="@+id/action_encodeResultFragment_to_encodeSetupFragment"
                 app:destination="@id/encodeSetupFragment"
-                app:popUpTo="@id/encodeSetupFragment"/>
+                app:launchSingleTop="false"
+                app:popUpTo="@id/encodeSetupFragment"
+                app:popUpToInclusive="false" >
+            </action>
+
         </fragment>
 
         <fragment
@@ -31,16 +44,21 @@
             tools:layout="@layout/fragment_decode_setup">
             <action
                 android:id="@+id/action_decodeSetupFragment_to_decodeResultFragment"
-                app:destination="@id/decodeResultFragment" />
+                app:destination="@id/decodeResultFragment" >
+            </action>
         </fragment>
         <fragment
             android:id="@+id/decodeResultFragment"
             android:name="com.example.steganography.fragments.decode.DecodeResultFragment"
             android:label="fragment_decode_result"
             tools:layout="@layout/fragment_decode_result" >
+            <argument
+                android:name="imageUri"
+                app:argType="string"/>
             <action
                 android:id="@+id/action_decodeResultFragment_to_decodeSetupFragment"
                 app:destination="@id/decodeSetupFragment"
-                app:popUpTo="@id/decodeSetupFragment" />
+                app:popUpTo="@id/decodeSetupFragment" >
+            </action>
         </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
     <string name="type_your_secret_message">type your secret message</string>
     <string name="save_picture">save Picture</string>
     <string name="encoded_message">encoded message</string>
+    <string name="take_a">take a</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,10 @@ buildscript {
         google()
     }
     dependencies {
-        def nav_version = "2.5.3"
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
+        classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.5.3'
     }
 }
+
 
 
 plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,15 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    repositories {
+        google()
+    }
+    dependencies {
+        def nav_version = "2.5.3"
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
+    }
+}
+
+
 plugins {
     id 'com.android.application' version '7.4.2' apply false
     id 'com.android.library' version '7.4.2' apply false
@@ -8,3 +19,4 @@ plugins {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+


### PR DESCRIPTION
- added the ability to pass data between fragments with Safe Args
Info about Safe args here: https://developer.android.com/guide/navigation/use-graph/pass-data
I pass the message as a string, and image Uri as a string from the Setup fragment to the Result fragment.
If you haven't added text or image, then you'll see a Toast message telling you this.

- Added SafeArgs to the readme technologies section

- Deleted 2 default photos.
The population of Sherks is decreasing drastically. Only 2 left...

**Screenshots!**

***Encode section:***
- Setup
Taking a picture
 <img src="https://github.com/neliudochka/steganography/assets/90915275/c5e22f61-f599-438c-a8c2-11b70a61c509" height="500">

Trying to press Start, but receiving a Toast message
 <img src="https://github.com/neliudochka/steganography/assets/90915275/47f41730-f95b-464b-82b2-b40dd36fecd3" height="500">

Entering a message
 <img src="https://github.com/neliudochka/steganography/assets/90915275/9f7d19d0-bbfc-4165-a251-c261cd81104c" height="500">

- Result
<img src="https://github.com/neliudochka/steganography/assets/90915275/dba65413-84cf-473f-899a-dcc2e83b3c9b" height="500">

***Decode section:***
- Setup
<img src="https://github.com/neliudochka/steganography/assets/90915275/e7967851-4c4e-4ce9-8966-e97572225fe7" height="500">

- Result
<img src="https://github.com/neliudochka/steganography/assets/90915275/ab56b9f3-0d8c-4802-ba6c-5bd799fb4233" height="500">

